### PR TITLE
Use libnx.specs for Switch linking

### DIFF
--- a/build/unix/make/buildtools-switch
+++ b/build/unix/make/buildtools-switch
@@ -3,9 +3,9 @@
 
 include build/unix/make/buildtools-generic
 
-# Link using libnx and portlibs without the default crt0
+# Link using libnx.specs and portlibs
 # $(LDFLAGS) should provide library paths to the Switch portlibs
 
 define act_link
-$(LINK) -nostartfiles -o "$@" $^ $(LDFLAGS) -lnx -lm
+$(LINK) -specs=libnx.specs -o "$@" $^ $(LDFLAGS) -lnx
 endef


### PR DESCRIPTION
## Summary
- simplify Switch link command
- rely on `libnx.specs` for start files and default libraries

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684b836e78908320bc57ed8daf7eefcb