### PR TITLE
Update Switch crossbuild docs

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -136,7 +136,8 @@ NINTENDO SWITCH
 ---------------
 To build for the Nintendo Switch you must have devkitA64 and the
 Switch portlibs installed from devkitPro.  Set the environment variables
-shown in build/unix/README.crossbuild and invoke the build script with
+shown in build/unix/README.crossbuild and ensure LDFLAGS includes
+"-specs=libnx.specs". Invoke the build script with
 
     ./build.sh uqm config
     ./build.sh uqm

--- a/build/unix/README.crossbuild
+++ b/build/unix/README.crossbuild
@@ -61,7 +61,7 @@ portlibs. Set the following environment variables before configuring:
     export PROG_gcc_FILE=aarch64-none-elf-gcc
     export PKG_CONFIG_PATH=$PORTLIBS_PREFIX/lib/pkgconfig
     export CFLAGS="-I$PORTLIBS_PREFIX/include"
-    export LDFLAGS="-L$PORTLIBS_PREFIX/lib"
+    export LDFLAGS="-L$PORTLIBS_PREFIX/lib -specs=libnx.specs"
 
 Then run:
 


### PR DESCRIPTION
## Summary
- clarify LDFLAGS example for Nintendo Switch in README.crossbuild
- mention `-specs=libnx.specs` when building the Switch port in INSTALL

## Testing
- `./build.sh uqm config` *(fails: Simple DirectMedia Layer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b876e9ca0832098c002741b18e8ce